### PR TITLE
resample using "right" interval boundary

### DIFF
--- a/technical/util.py
+++ b/technical/util.py
@@ -55,7 +55,8 @@ def resample_to_interval(dataframe, interval):
         'close': 'last',
         'volume': 'sum'
     }
-    df = df.resample(str(interval) + 'min').agg(ohlc_dict).dropna()
+    df = df.resample(str(interval) + 'min',
+                     label="right").agg(ohlc_dict).dropna()
     df['date'] = df.index
 
     return df


### PR DESCRIPTION
discovered in https://github.com/freqtrade/freqtrade/issues/1198

corresponding pandas docu entry:
https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.resample.html

if the left boundary is used, then we're backpainting in backtesting (as the close-signal is available before the candle is closed) - which leads to perfect backtesting strategies ... but non-working real strategies...

